### PR TITLE
Dockerize

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,32 @@ Yeoman generator for creating RESTful NodeJS APIs, using ES6, Mongoose and Expre
 - Run: `yo api`, or `yo` and choose `Api` option
 
 ## Running the generated project
-Make sure you have node version `>= 6.3` because this project uses native supported ES6 features.
 
-- Run: `mongod` to start the local mongodb instance. If you don't have mongodb installed locally, visit [their webpage](https://docs.mongodb.com/manual/installation/)
-- Run: `npm run dev` to start the local server with nodemon at `localhost:8080`
+If chose not to use Docker, make sure you have node version `>= 6.3` because this project uses native supported ES6 features.
+
+To start the local mongodb instance run in a separated terminal instance:
+
+```bash
+mongod
+```
+
+NOTE: _If you don't have mongodb installed locally, visit [their webpage](https://docs.mongodb.com/manual/installation/)._
+
+Run the app with:
+
+```bash
+npm run dev
+```
+
+Now visit the app at `localhost:8080`.
+
+If you chose to have Docker :whale: support, you only need [Docker](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install/) installed.
+
+To run the app:
+
+```bash
+sudo docker-compose up
+```
 
 ## Architecture
 The idea is to be able to scale having a simple architecture. Assuming we use `user` and `pet` as models the generated project would look like this:

--- a/README.md
+++ b/README.md
@@ -21,31 +21,22 @@ Yeoman generator for creating RESTful NodeJS APIs, using ES6, Mongoose and Expre
 
 ## Running the generated project
 
-If chose not to use Docker, make sure you have node version `>= 6.3` because this project uses native supported ES6 features.
+Make sure you have node version `>= 6.3` because this project uses native supported ES6 features.
 
-To start the local mongodb instance run in a separated terminal instance:
-
-```bash
-mongod
-```
+- Run: `mongod` to start the local mongodb in a separated terminal instance.
+- Run: `npm run dev` to run the app.
 
 NOTE: _If you don't have mongodb installed locally, visit [their webpage](https://docs.mongodb.com/manual/installation/)._
 
-Run the app with:
+Did you choose Docker support? :whale:
 
-```bash
-npm run dev
-```
+You only need [Docker](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install/) installed.
+
+- Run: `docker-compose up` to run the app. _You might need `sudo` for this one_.
+
+-------------------------------------------------------------------------------
 
 Now visit the app at `localhost:8080`.
-
-If you chose to have Docker :whale: support, you only need [Docker](https://docs.docker.com/engine/installation/) and [docker-compose](https://docs.docker.com/compose/install/) installed.
-
-To run the app:
-
-```bash
-sudo docker-compose up
-```
 
 ## Architecture
 The idea is to be able to scale having a simple architecture. Assuming we use `user` and `pet` as models the generated project would look like this:
@@ -81,8 +72,9 @@ In `lib/facade` you have the basic support for RESTful methods. Because this cla
 
 
 ## To do
-*  Create more generator templates to add new models once the project was initialized
+* Create more generator templates to add new models once the project was initialized
 * Implement testing in the generated project
+* Improve Docker support for production environments
 
 ## Contributing
 Contributors are welcome, please fork and send pull requests! If you have any ideas on how to improve this project please submit an issue.

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -59,6 +59,11 @@ const serverGenerator = generators.Base.extend({
         type    : 'input',
         message : 'what should the database be named?',
         default : (answers) => to.slug(answers.serverName)
+      }, {
+        name    : 'useDocker',
+        type    : 'confirm',
+        message : 'would you like to have Docker included in the app?',
+        default : true
       }]).then(answers => {
         this.serverName        = answers.serverName;
         this.serverDescription = answers.serverDescription;
@@ -67,6 +72,7 @@ const serverGenerator = generators.Base.extend({
         this.authorEmail       = answers.authorEmail;
         this.databaseName      = answers.databaseName;
         this.models            = answers.models.map(genModelNames);
+        this.useDocker         = answers.useDocker;
       });
     }
   },
@@ -177,6 +183,26 @@ const serverGenerator = generators.Base.extend({
           }
         );
       });
+    }
+  },
+
+  dockerfile() {
+    if (this.useDocker) {
+      this.fs.copy(
+        this.templatePath('Dockerfile'),
+        this.destinationPath('Dockerfile')
+      );
+    }
+  },
+
+  dockercompose() {
+    if (this.useDocker) {
+      this.fs.copyTpl(
+        this.templatePath('docker-compose.yml'),
+        this.destinationPath('docker-compose.yml'), {
+          databaseName: this.databaseName
+        }
+      );
     }
   },
 

--- a/generators/app/templates/Dockerfile
+++ b/generators/app/templates/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:wheezy
+
+ENV APP_HOME /app/
+ENV TEMP_NPM /temp
+
+RUN mkdir $APP_HOME
+
+# caching npm packages
+WORKDIR $TEMP_NPM
+COPY package.json $TEMP_NPM
+RUN npm config set registry https://registry.npmjs.org/
+RUN npm install --silent
+RUN cp -a $TEMP_NPM/node_modules $APP_HOME
+
+WORKDIR $APP_HOME
+
+COPY ./ $APP_HOME
+
+EXPOSE 8080
+
+CMD ["npm", "run", "dev"]

--- a/generators/app/templates/config.js
+++ b/generators/app/templates/config.js
@@ -3,10 +3,10 @@ const milieu = require('milieu');
 const config = milieu('<%= serverName %>', {
   environment: 'dev',
   server: {
-    port: 8080
+    port: '${PORT}' || 8080
   },
   mongo: {
-    url: 'mongodb://localhost/<%= databaseName %>'
+    url: '${MONGO_DB_URI}' || 'mongodb://localhost/<%= databaseName %>'
   }
 });
 

--- a/generators/app/templates/docker-compose.yml
+++ b/generators/app/templates/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '2'
+
+services:
+  web:
+    build: .
+    volumes:
+      - ./:/app
+    ports:
+      - "8080:8080"
+    links:
+      - mongo
+    environment:
+      - MONGO_DB_URI=mongodb://mongo:27017/<%= databaseName %>
+
+  mongo:
+    image: mongo
+    ports:
+      - "27017:27017"
+    volumes_from:
+      - mongodata
+
+  mongodata:
+    image: tianon/true
+    volumes:
+      - /data/db

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "eslint": "eslint . --ext .js"
   },
   "author": "ndelvalle <nicolas.delvalle@gmail.com>",
+  "contributors":[
+    "Christian Gill <gillchristiang@gmail.com> (https://gillchristian.xyz/)"
+  ],
   "license": "MIT",
   "keywords": [
     "yeoman-generator",

--- a/test/included-files-cases.js
+++ b/test/included-files-cases.js
@@ -1,0 +1,32 @@
+const includedFiles = [
+  {
+    desc : 'generates an index.js file',
+    files: ['index.js']
+  },
+  {
+    desc : 'generates a router.js file',
+    files: ['routes.js']
+  },
+  {
+    desc : 'generates a package.json file',
+    files: ['package.json']
+  },
+  {
+    desc : 'generates a .eslintignore file',
+    files: ['.eslintignore']
+  },
+  {
+    desc : 'generates a .eslintrc.json file',
+    files: ['.eslintrc.json']
+  },
+  {
+    desc : 'generates a .gitignore file',
+    files: ['.gitignore']
+  },
+  {
+    desc : 'generates a config.js file',
+    files: ['config.js']
+  }
+];
+
+module.exports = includedFiles;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,12 +1,13 @@
 /* eslint-disable max-len */
 /* global describe before it */
 
-const helpers = require('yeoman-test');
-const assert  = require('yeoman-assert');
-const path    = require('path');
+const helpers       = require('yeoman-test');
+const assert        = require('yeoman-assert');
+const path          = require('path');
+const includedFiles = require('./included-files-cases');
 
 describe('generator-api', () => {
-  describe('Run yeoman generator-api', () => {
+  describe('Run yeoman generator-api with no docker support', () => {
 
     before(() => helpers.run(path.join(__dirname, '../generators/app'))
       .withPrompts({
@@ -16,36 +17,29 @@ describe('generator-api', () => {
         authorName       : 'authorName',
         authorEmail      : 'authorEmail',
         models           : ['foo', 'bar', 'BazFoo'],
-        databaseName     : 'databaseName'
+        databaseName     : 'databaseName',
+        useDocker        : false
       })
       .toPromise());
 
-    it('generates an index.js file', () => {
-      assert.file(['index.js']);
+
+    includedFiles.forEach(fileCase => {
+      it(fileCase.desc, () => {
+        assert.file(fileCase.files);
+      });
     });
 
-    it('generates a router.js file', () => {
-      assert.file(['routes.js']);
-    });
+    const notIncludedFiles = [
+      {
+        desc : 'doest not generate docker files when useDocker = false',
+        files: ['Dockerfile', 'docker-compose.yml']
+      }
+    ];
 
-    it('generates a package.json file', () => {
-      assert.file(['package.json']);
-    });
-
-    it('generates a .eslintignore file', () => {
-      assert.file(['.eslintignore']);
-    });
-
-    it('generates a .eslintrc.json file', () => {
-      assert.file(['.eslintrc.json']);
-    });
-
-    it('generates a .gitignore file', () => {
-      assert.file(['.gitignore']);
-    });
-
-    it('generates a config.js file', () => {
-      assert.file(['config.js']);
+    notIncludedFiles.forEach(fileCase => {
+      it(fileCase.desc, () => {
+        assert.noFile(fileCase.files);
+      });
     });
 
     describe('models', () => {
@@ -106,6 +100,26 @@ describe('generator-api', () => {
       it('generates a lib/facade.js file', () => {
         assert.file(['lib/facade.js']);
       });
+    });
+  });
+
+  describe('Run yeoman generator-api with docker support', () => {
+
+    before(() => helpers.run(path.join(__dirname, '../generators/app'))
+      .withPrompts({
+        serverName       : 'serverName',
+        serverDescription: 'serverDescription',
+        serverVersion    : 'serverVersion',
+        authorName       : 'authorName',
+        authorEmail      : 'authorEmail',
+        models           : ['foo'],
+        databaseName     : 'databaseName',
+        useDocker        : true
+      })
+      .toPromise());
+
+    it('generates docker files when useDocker = true', () => {
+      assert.file('Dockerfile', 'docker-compose.yml');
     });
   });
 });


### PR DESCRIPTION
This PR adds:

- Support for setting app port and mongodb uri via env vars.
- Dockerize the generated app
    - Run the app in a [node:wheezy](https://hub.docker.com/_/node/) container.
    - Run [mongodb](https://hub.docker.com/_/mongo/) in a container.
    - Persist data using [tianon/true](https://hub.docker.com/r/tianon/true/) container.
    - Run everything with docker-compose.