### PR TITLE
Query spread to support Mongo Query options

### DIFF
--- a/example/lib/facade.js
+++ b/example/lib/facade.js
@@ -14,15 +14,15 @@ class Facade {
     .exec();
   }
 
-  find(query) {
+  find(...query) {
     return this.Schema
-    .find(query)
+    .find(...query)
     .exec();
   }
 
-  findOne(query) {
+  findOne(...query) {
     return this.Schema
-    .findOne(query)
+    .findOne(...query)
     .exec();
   }
 

--- a/generators/app/templates/lib/facade.js
+++ b/generators/app/templates/lib/facade.js
@@ -14,15 +14,15 @@ class Facade {
     .exec();
   }
 
-  find(query) {
+  find(...query) {
     return this.Schema
-    .find(query)
+    .find(...query)
     .exec();
   }
 
-  findOne(query) {
+  findOne(...query) {
     return this.Schema
-    .findOne(query)
+    .findOne(...query)
     .exec();
   }
 


### PR DESCRIPTION
I've added args spread to support Mongoose Query options.
Find and findOne can be queried like that:
`userFacade.findOne({_id:req.params.id},'username _id')`
This code will provide select option to query.

And also, now it looks like a better support of Mongoose queries.
