### PR TITLE
Hotfix/minor attribute name change

### DIFF
--- a/generators/app/templates/lib/facade.js
+++ b/generators/app/templates/lib/facade.js
@@ -1,39 +1,41 @@
-class Facade {
-  constructor(Schema) {
-    this.Schema = Schema;
+const mongoose = require('mongoose');
+
+Model Facade {
+  constructor(name, schema) {
+    this.model = mongoose.model(name, schema);
   }
 
   create(body) {
-    const schema = new this.Schema(body);
-    return schema.save();
+    const model = new this.model(body);
+    return model.save();
   }
 
   find(...args) {
-    return this.Schema
+    return this.model
       .find(...args)
       .exec();
   }
 
   findOne(...args) {
-    return this.Schema
+    return this.model
       .findOne(...args)
       .exec();
   }
 
   findById(...args) {
-    return this.Schema
+    return this.model
       .findById(...args)
       .exec();
   }
 
   update(...args) {
-    return this.Schema
+    return this.model
       .update(...args)
       .exec();
   }
 
   remove(...args) {
-    return this.Schema
+    return this.model
       .remove(...args)
       .exec();
   }

--- a/generators/app/templates/lib/facade.js
+++ b/generators/app/templates/lib/facade.js
@@ -1,6 +1,6 @@
 const mongoose = require('mongoose');
 
-Model Facade {
+class Facade {
   constructor(name, schema) {
     this.model = mongoose.model(name, schema);
   }

--- a/generators/app/templates/model/facade.js
+++ b/generators/app/templates/model/facade.js
@@ -3,4 +3,4 @@ const <%= model.camelName %>Schema = require('./schema');
 
 class <%= model.pascalName %>Facade extends Facade {}
 
-module.exports = new <%= model.pascalName %>Facade(<%= model.camelName %>Schema);
+module.exports = new <%= model.pascalName %>Facade('<%= model.pascalName %>', <%= model.camelName %>Schema);

--- a/generators/app/templates/model/schema.js
+++ b/generators/app/templates/model/schema.js
@@ -1,4 +1,4 @@
-const mongoose = require('mongoose');
+
 const Schema = mongoose.Schema;
 
 
@@ -8,4 +8,4 @@ const <%= model.camelName %>Schema = new Schema({
 });
 
 
-module.exports = mongoose.model('<%= model.pascalName %>', <%= model.camelName %>Schema);
+module.exports =  <%= model.camelName %>Schema;


### PR DESCRIPTION
1. rename attribute name Scheme to be model in lib template facade.js
2. export Schema instead of Model in model template schema.js to make it consistent with file name. Instantiate the model in facade.js with the schema.

Note that I couldn't get this tested locally with some sample models.  Actually I really don't know how to run test locally.  Please double check before merge or let me know how to do the test,