### PR TITLE
Fixed docker volume

### DIFF
--- a/generators/app/templates/docker-compose.yml
+++ b/generators/app/templates/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     command: npm run dev
     build: .
     volumes:
-      - ./:/app
+      - ./:/usr/src/app
     ports:
       - "8080:8080"
     links:


### PR DESCRIPTION
Absolute path of the volume inside the container should be /usr/src/app as defined in [Dockerfile#L5](https://github.com/ndelvalle/generator-api/blob/8a87caba9fdc2c7800735d30af8d4b61c6e77139/generators/app/templates/Dockerfile#L5).